### PR TITLE
Remove cpuLimit by default and change memoryLimit to match memoryRequest

### DIFF
--- a/charts/mi-adf-shir/Chart.yaml
+++ b/charts/mi-adf-shir/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mi-adf-shir
 home: https://github.com/hmcts/mi-adf-integration-runtime/
-version: 1.0.7
+version: 1.1.0
 description: Node for a Azure Data Factory Self Hosted Integration Runtime
 maintainers:
   - name: HMCTS Management Information Platform

--- a/charts/mi-adf-shir/templates/deployment.yaml
+++ b/charts/mi-adf-shir/templates/deployment.yaml
@@ -73,8 +73,10 @@ spec:
               memory: {{ .Values.memoryRequests }}
               cpu: {{ .Values.cpuRequests }}
             limits:
-              memory: {{ .Values.memoryLimits }}
-              cpu: {{ .Values.cpuLimits }}
+              memory: {{ .Values.memoryLimits }} # the memory limit should equal the request.
+              {{ if .Values.cpuLimits }}
+              cpu: {{ .Values.cpuLimits }} # no cpu limit is preferred for performance.
+              {{ end }}
       {{ if .Values.nodeName }}
       nodeName: {{ .Values.nodeName }}
       {{ end }}

--- a/charts/mi-adf-shir/values.yaml
+++ b/charts/mi-adf-shir/values.yaml
@@ -24,5 +24,6 @@ shirNodeName: ''
 haEnabled: "true"
 haPort: "8060"
 
-memoryRequests: '1024Mi'
+memoryRequests: '2048Mi'
+memoryLimits: '2048Mi'
 cpuRequests: '500m'

--- a/charts/mi-adf-shir/values.yaml
+++ b/charts/mi-adf-shir/values.yaml
@@ -26,5 +26,3 @@ haPort: "8060"
 
 memoryRequests: '1024Mi'
 cpuRequests: '500m'
-memoryLimits: '2048Mi'
-cpuLimits: '2000m'


### PR DESCRIPTION
Per this article:

https://home.robusta.dev/blog/kubernetes-memory-limit

Setting no cpuLimit is best practice, and other articles can be found showing perf improvements from 2x to 20x as most cpuLimits are not set correctly.

Setting memoryLimit to equal to memoryRequest is preferred as a non-compressible resource.