### PR TITLE
Update deployment labels

### DIFF
--- a/charts/mi-adf-shir/templates/deployment.yaml
+++ b/charts/mi-adf-shir/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: {{ .Values.appName }}
         aadpodidbinding: {{ .Values.aadIdentityName }}
+        ignored-by-dynatrace: "true"
     spec:
       volumes:
         {{ if .Values.secretsMountPath }}


### PR DESCRIPTION
We have changed the dynatrace-operator to ignore certain label in https://github.com/hmcts/sds-flux-config/pull/3048/files - but we can't patch this via flux as the deployment resource doesn't exist https://github.com/hmcts/sds-flux-config/pull/3049



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
